### PR TITLE
Add --library arguments for jextract

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ This is a Maven wrapper for the [`jextract`](https://github.com/openjdk/jextract
 			</goals>
 			<configuration>
 				<headerFile>point.h</headerFile>
+				<libraries>
+					<library>/path/to/shared/library.so</library>
+				</libraries>
 				<targetPackage>com.example.mypackage</targetPackage>
 				<headerClassName>Point2d</headerClassName>
 				<includeStructs>

--- a/src/main/java/io/github/coffeelibs/maven/jextract/SourcesMojo.java
+++ b/src/main/java/io/github/coffeelibs/maven/jextract/SourcesMojo.java
@@ -206,7 +206,6 @@ public class SourcesMojo extends AbstractMojo {
 			args.add("--include-var");
 			args.add(str);
 		});
-		args.add("--source");
 		args.add(headerFile);
 
 		getLog().debug("Running: " + String.join(" ", args));

--- a/src/main/java/io/github/coffeelibs/maven/jextract/SourcesMojo.java
+++ b/src/main/java/io/github/coffeelibs/maven/jextract/SourcesMojo.java
@@ -129,6 +129,15 @@ public class SourcesMojo extends AbstractMojo {
 
 	/**
 	 * <dl>
+	 *     <dt>--library</dt>
+	 *     <dd>path to shared libraries to load</dd>
+	 * </dl>
+	 */
+	@Parameter(property = "jextract.libraries", required = false)
+	private String[] libraries;
+
+	/**
+	 * <dl>
 	 *     <dt>--output</dt>
 	 *     <dd>specify the directory to place generated files</dd>
 	 * </dl>
@@ -161,6 +170,10 @@ public class SourcesMojo extends AbstractMojo {
 		args.add(outputDirectory.getAbsolutePath());
 		args.add("--target-package");
 		args.add(targetPackage);
+		Arrays.stream(libraries).forEach(str -> {
+			args.add("--library");
+			args.add(str);
+		});
 		Arrays.stream(headerSearchPaths).forEach(str -> {
 			args.add("-I");
 			args.add(str);
@@ -193,6 +206,7 @@ public class SourcesMojo extends AbstractMojo {
 			args.add("--include-var");
 			args.add(str);
 		});
+		args.add("--source");
 		args.add(headerFile);
 
 		getLog().debug("Running: " + String.join(" ", args));


### PR DESCRIPTION
Without the `--source` argument, the plugin generates `.class` files instead of `.java` files. The `.java` files can be easily imported from user code.

Without the `--library` argument, jextract does not load the implementation of the header file. Adding a library parameter configurable so users can point to their .so files.